### PR TITLE
fix(db): get_optimized_dashboard_statsの戻り値の不整合を修正

### DIFF
--- a/supabase/migrations/20250730010000_unified_schema.sql
+++ b/supabase/migrations/20250730010000_unified_schema.sql
@@ -499,7 +499,7 @@ BEGIN
     r.reservation_count,
     s.new_customers,
     ac.cast_count,
-    ls.low_stock_items
+    ls.low_stock_items AS low_stock_count
   FROM stats s
   CROSS JOIN reservations r
   CROSS JOIN active_cast ac


### PR DESCRIPTION
データベース関数 `get_optimized_dashboard_stats` が返すカラム名と、それを呼び出すTypeScriptコード (`src/app/(protected)/dashboard/actions.ts`) が期待しているプロパティ名に不一致があるため修正しました。

### エラーの根本原因

**原因は、データベース関数 `get_optimized_dashboard_stats` が返すカラム名と、それを呼び出すTypeScriptコード (`src/app/(protected)/dashboard/actions.ts`) が期待しているプロパティ名に不一致があるためです。**

具体的には、「在庫僅少アイテム数」の項目でズレが生じています。

---

### 詳細な分析

1.  **データベース関数 (`get_optimized_dashboard_stats`) の定義:**
    この関数が返すカラム（戻り値の型）は `low_stock_count` と定義されています。

2.  **データベース関数内のSELECT文:**
    しかし、実際の `SELECT` 文では、`low_stock_items` という名前でカラムを選択しています。

3.  **TypeScriptコード (`actions.ts`) の期待値:**
    フロントエンドのコードは、関数の定義通り `low_stock_count` という名前のプロパティを期待してデータを取得しようとします。

この結果、TypeScript側で `data.low_stock_count` を参照した際に `undefined` となり、ダッシュボードには常に `0` と表示されてしまいます。これがエラーまたは不正確なデータ表示の原因です。

---

### 解決策

データベース関数の `SELECT` 文を修正し、返すカラム名を定義と一致させます。具体的には `ls.low_stock_items` を `low_stock_count` としてエイリアス（別名）を付けました。