### PR TITLE
feat: サーバーコンポーネントにローディング画面を追加

### DIFF
--- a/src/app/(protected)/attendance/loading.tsx
+++ b/src/app/(protected)/attendance/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from "@/components/common";
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <LoadingSpinner size="lg" />
+    </div>
+  );
+}

--- a/src/app/(protected)/customers/[id]/loading.tsx
+++ b/src/app/(protected)/customers/[id]/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from "@/components/common";
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <LoadingSpinner size="lg" />
+    </div>
+  );
+}

--- a/src/app/(protected)/customers/loading.tsx
+++ b/src/app/(protected)/customers/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from "@/components/common";
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <LoadingSpinner size="lg" />
+    </div>
+  );
+}

--- a/src/app/(protected)/dashboard/loading.tsx
+++ b/src/app/(protected)/dashboard/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from "@/components/common";
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <LoadingSpinner size="lg" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Next.js App Routerのstreaming UIを活用し、サーバーコンポーネントのデータ取得中にローディング画面を表示するように改善しました。これにより、画面遷移が即座に開始され、体感的なパフォーマンスが大幅に向上します。

## Problem
- サーバーコンポーネントでデータ取得を行うページ（`async function`）では、`loading.tsx`がないとデータ取得が完了するまで画面遷移が開始されない
- ユーザーがリンクをクリックしても反応がないように感じる

## Solution
以下のページに`loading.tsx`を追加：
- ✅ 勤怠管理ページ (`/attendance`)
- ✅ 顧客管理一覧ページ (`/customers`)
- ✅ 顧客詳細ページ (`/customers/[id]`)
- ✅ ダッシュボードページ (`/dashboard`)

※ 在庫管理ページ (`/inventory`) は既に対応済み

## Implementation
既存の`inventory/loading.tsx`と同じ実装を使用：
- 中央配置されたローディングスピナー
- 最小高さ400pxで統一感のあるUI

## Test plan
- [x] TypeScriptコンパイルエラーなし
- [x] ESLintエラーなし
- [ ] 各ページでローディング画面が表示されることを確認
- [ ] データ取得完了後、正しくコンテンツが表示されることを確認

## Note
クライアントコンポーネント（`"use client"`）のページは、既に独自のローディング状態管理を実装しているため、今回の対象外としています。

🤖 Generated with [Claude Code](https://claude.ai/code)